### PR TITLE
Add a new way to set `from` transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install `machinist` by adding it  to your list of dependencies in `mix.e
 ```elixir
 def deps do
   [
-    {:machinist, "~> 0.3.0"}
+    {:machinist, "~> 0.4.0"}
   ]
 end
 ```
@@ -76,6 +76,28 @@ If we try to make a transition that not follow the rules, we got an error:
 iex> Door.transit(door_opened, event: "lock")
 {:error, :not_allowed}
 ```
+
+### Group same-state `from` definitions
+
+In the example above we could group the `from :unlocked` definitions like this:
+
+```elixir
+# ...
+transitions do
+  from :locked, to: :unlocked, event: "unlock"
+  from :unlocked do
+    to :locked, event: "lock"
+    to :opened, event: "open"
+  end
+  from :opened, to: :closed,   event: "close"
+  from :closed, to: :opened,   event: "open"
+  from :closed, to: :locked,   event: "lock"
+end
+# ...
+```
+
+This is an option to a better organization and an increase of readability when having
+a large number of `from` definitions with a same state.
 
 ### Setting different attribute name that holds the state
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,13 @@
 defmodule Machinist.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
   @repo_url "https://github.com/norbajunior/machinist"
 
   def project do
     [
       app: :machinist,
-      version: "0.3.0",
+      version: @version,
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/machinist_test.exs
+++ b/test/machinist_test.exs
@@ -131,8 +131,12 @@ defmodule MachinistTest do
       transitions do
         from(:new, to: :registered, event: "register")
         from(:registered, to: :interview_scheduled, event: "schedule_interview")
-        from(:interview_scheduled, to: :approved, event: "approve_interview")
-        from(:interview_scheduled, to: :repproved, event: "reprove_interview")
+
+        from :interview_scheduled do
+          to(:approved, event: "approve_interview")
+          to(:repproved, event: "reprove_interview")
+        end
+
         from(:approved, to: :enrolled, event: "enroll")
         from(_state, to: :application_expired, event: "application_expired")
       end
@@ -150,6 +154,31 @@ defmodule MachinistTest do
 
       {:ok, %Example5{state: :application_expired}} =
         Example5.transit(%Example5{state: :approved}, event: "application_expired")
+    end
+  end
+
+  describe "a example with passing a block of transitions to from" do
+    defmodule Example6 do
+      defstruct state: :test
+
+      use Machinist
+
+      transitions do
+        from(:test, to: :test1, event: "test1")
+
+        from :test1 do
+          to(:test2, event: "test2")
+          to(:test3, event: "test3")
+          to(:test4, event: "test4")
+        end
+      end
+    end
+
+    test "all transitions" do
+      assert {:ok, example} = Example6.transit(%Example6{}, event: "test1")
+      assert {:ok, %Example6{state: :test2}} = Example6.transit(example, event: "test2")
+      assert {:ok, %Example6{state: :test3}} = Example6.transit(example, event: "test3")
+      assert {:ok, %Example6{state: :test4}} = Example6.transit(example, event: "test4")
     end
   end
 end


### PR DESCRIPTION
With this new feature we can group many `from` definitions with a same state.

* Add macro `Machinist.from/2` that expects a `state` and a block of `to` statements

```elixir
 # ...
 transitions do
   from :locked, to: :unlocked, event: "unlock"
   from :unlocked do
     to :locked, event: "lock"
     to :opened, event: "open"
   end
   from :opened, to: :closed,   event: "close"
   from :closed, to: :opened,   event: "open"
   from :closed, to: :locked,   event: "lock"
 end
 # ...
 ```