### PR TITLE
Fix dialyzer warning of __set_new_state__ private function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install `machinist` by adding it  to your list of dependencies in `mix.e
 ```elixir
 def deps do
   [
-    {:machinist, "~> 0.4.0"}
+    {:machinist, "~> 0.4.1"}
   ]
 end
 ```

--- a/lib/machinist.ex
+++ b/lib/machinist.ex
@@ -405,11 +405,13 @@ defmodule Machinist do
         {:error, :not_allowed}
       end
 
-      defp __set_new_state__(resource, new_state) when is_function(new_state) do
-        new_state.(resource)
+      defp __set_new_state__(resource, new_state) do
+        if is_function(new_state) do
+          new_state.(resource)
+        else
+          new_state
+        end
       end
-
-      defp __set_new_state__(_, new_state), do: new_state
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Machinist.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.4.1"
   @repo_url "https://github.com/norbajunior/machinist"
 
   def project do


### PR DESCRIPTION
When `__before_compile__` callback injects the two `__set_new_state__` functions, being one of them
with a guard clause checking if the `new_state` is a function

```elixir
defp __set_new_state__(resource, new_state) when is_function(new_state) do
  new_state.(resource)
end

defp __set_new_state__(_, new_state), do: new_state
```

and the transitions defined in the module using machinist has all `to: state` definitions with `state` being a string, the `__set_new_state__/2 when is_function/1` will never be used. That’s why dialyzer reports the following warning:

```
The guard test:

is_function(_ :: <<_::64, _::size(8)>>)

can never succeed.
```

Closes #6 