### PR TITLE
Add introspection functions to states, events and transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 machinist-*.tar
 
-
 # Temporary files for e.g. tests
 /tmp
+
+/.elixir_ls

--- a/README.md
+++ b/README.md
@@ -225,6 +225,21 @@ defmodule SelectionProcess.V2 do
 end
 ```
 
+## Introspection
+
+To get the list of states of our state machine module, just call:
+
+```elixir
+iex> SelectionProcess.V2.__states__()
+[:new, :registered, :interview_scheduled, :approved, :reproved, :enrolled]
+```
+
+To get the list of events:
+
+```elixir
+iex> SelectionProcess.V2.__events__()
+["register", "schedule_interview", "approve_interview", "reprove_interview", "enroll"]
+
 ## How does the DSL works?
 
 The use of `transitions` in combination with each `from` statement will be transformed in functions that will be injected into the module that is using `machinist`.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ end
 
 ## Introspection
 
-To get the list of states of our state machine module, just call:
+To get the list of states, just call:
 
 ```elixir
 iex> SelectionProcess.V2.__states__()
@@ -239,6 +239,20 @@ To get the list of events:
 ```elixir
 iex> SelectionProcess.V2.__events__()
 ["register", "schedule_interview", "approve_interview", "reprove_interview", "enroll"]
+```
+
+To get the list of all transitions:
+
+```elixir
+iex>  SelectionProcess.V2.__transitions__()
+[
+  [from: :new, to: :registered, event: "register"],
+  [from: :registered, to: :interview_scheduled, event: "schedule_interview"],
+  [from: :interview_scheduled, to: :approved, event: "approve_interview"],
+  [from: :interview_scheduled, to: :repproved, event: "reprove_interview"],
+  [from: :approved, to: :enrolled, event: "enroll"]
+]
+```
 
 ## How does the DSL works?
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install `machinist` by adding it  to your list of dependencies in `mix.e
 ```elixir
 def deps do
   [
-    {:machinist, "~> 0.4.1"}
+    {:machinist, "~> 0.5.1"}
   ]
 end
 ```

--- a/lib/machinist.ex
+++ b/lib/machinist.ex
@@ -192,6 +192,21 @@ defmodule Machinist do
         end
       end
 
+  ## Introspection
+
+  To get the list of states of our state machine, just call:
+
+  ```elixir
+  iex> SelectionProcess.V2.__states__()
+  [:new, :registered, :interview_scheduled, :approved, :reproved, :enrolled]
+  ```
+
+  To get the list of events:
+
+  ```elixir
+  iex> SelectionProcess.V2.__events__()
+  ["register", "schedule_interview", "approve_interview", "reprove_interview", "enroll"]
+
   ## How does the DSL works?
 
   The use of `transitions` in combination with each `from` statement will be

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Machinist.MixProject do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.5.1"
   @repo_url "https://github.com/norbajunior/machinist"
 
   def project do

--- a/test/machinist_test.exs
+++ b/test/machinist_test.exs
@@ -28,6 +28,13 @@ defmodule MachinistTest do
     test "__events__/0" do
       assert Example1.__events__() == ~w(next)
     end
+
+    test "__transitions__/0" do
+      assert Example1.__transitions__() == [
+               [from: 1, to: 2, event: "next"],
+               [from: 2, to: 3, event: "next"]
+             ]
+    end
   end
 
   describe "an example with custom state attribute" do
@@ -55,6 +62,13 @@ defmodule MachinistTest do
 
     test "__events__/0" do
       assert Example2.__events__() == ~w(next)
+    end
+
+    test "__transitions__/0" do
+      assert Example2.__transitions__() == [
+               [from: 1, to: 2, event: "next"],
+               [from: 2, to: 3, event: "next"]
+             ]
     end
   end
 
@@ -127,6 +141,19 @@ defmodule MachinistTest do
       assert SelectionProcess.V1.__events__() == ~w(register enroll)
       assert SelectionProcess.V2.__events__() == ~w(register interviewed enroll)
     end
+
+    test "__transitions__/0" do
+      assert SelectionProcess.V1.__transitions__() == [
+               [from: :new, to: :registered, event: "register"],
+               [from: :registered, to: :enrolled, event: "enroll"]
+             ]
+
+      assert SelectionProcess.V2.__transitions__() == [
+               [from: :new, to: :registered, event: "register"],
+               [from: :registered, to: :interviewed, event: "interviewed"],
+               [from: :interviewed, to: :enrolled, event: "enroll"]
+             ]
+    end
   end
 
   describe "an example of a module handling a different struct with custom state attr" do
@@ -153,6 +180,10 @@ defmodule MachinistTest do
 
     test "__events__/0" do
       assert Example4.__events__() == ~w(next)
+    end
+
+    test "__transitions__/0" do
+      assert Example4.__transitions__() == [[from: 1, to: 2, event: "next"]]
     end
   end
 
@@ -199,6 +230,26 @@ defmodule MachinistTest do
       assert Example5.__events__() ==
                ~w(register schedule_interview approve_interview reprove_interview enroll application_expired)
     end
+
+    test "__transitions__/0" do
+      assert Example5.__transitions__() == [
+               [from: :new, to: :registered, event: "register"],
+               [from: :registered, to: :interview_scheduled, event: "schedule_interview"],
+               [from: :interview_scheduled, to: :approved, event: "approve_interview"],
+               [from: :interview_scheduled, to: :reproved, event: "reprove_interview"],
+               [from: :approved, to: :enrolled, event: "enroll"],
+               [from: :new, to: :application_expired, event: "application_expired"],
+               [from: :registered, to: :application_expired, event: "application_expired"],
+               [
+                 from: :interview_scheduled,
+                 to: :application_expired,
+                 event: "application_expired"
+               ],
+               [from: :approved, to: :application_expired, event: "application_expired"],
+               [from: :reproved, to: :application_expired, event: "application_expired"],
+               [from: :enrolled, to: :application_expired, event: "application_expired"]
+             ]
+    end
   end
 
   describe "a example with passing a block of transitions to from" do
@@ -219,6 +270,7 @@ defmodule MachinistTest do
     end
 
     test "all transitions" do
+      IO.inspect(Example6.__transitions__())
       assert {:ok, example} = Example6.transit(%Example6{}, event: "test1")
       assert {:ok, %Example6{state: :test2}} = Example6.transit(example, event: "test2")
       assert {:ok, %Example6{state: :test3}} = Example6.transit(example, event: "test3")
@@ -231,6 +283,15 @@ defmodule MachinistTest do
 
     test "__events__/0" do
       assert Example6.__events__() == ~w(test1 test2 test3 test4)
+    end
+
+    test "__transitions__/0" do
+      assert Example6.__transitions__() == [
+               [from: :test, to: :test1, event: "test1"],
+               [from: :test1, to: :test2, event: "test2"],
+               [from: :test1, to: :test3, event: "test3"],
+               [from: :test1, to: :test4, event: "test4"]
+             ]
     end
   end
 end

--- a/test/machinist_test.exs
+++ b/test/machinist_test.exs
@@ -20,6 +20,14 @@ defmodule MachinistTest do
 
       assert {:error, :not_allowed} = Example1.transit(step_3, event: "next")
     end
+
+    test "__states__/0" do
+      assert Example1.__states__() == [1, 2, 3]
+    end
+
+    test "__events__/0" do
+      assert Example1.__events__() == ~w(next)
+    end
   end
 
   describe "an example with custom state attribute" do
@@ -39,6 +47,14 @@ defmodule MachinistTest do
       assert {:ok, %Example2{step: 3} = step_3} = Example2.transit(step_2, event: "next")
 
       assert {:error, :not_allowed} = Example2.transit(step_3, event: "next")
+    end
+
+    test "__states__/0" do
+      assert Example2.__states__() == [1, 2, 3]
+    end
+
+    test "__events__/0" do
+      assert Example2.__events__() == ~w(next)
     end
   end
 
@@ -101,6 +117,16 @@ defmodule MachinistTest do
       {:error, :not_allowed} = SelectionProcess.V2.transit(enrolled_candidate, event: "enroll")
       {:error, :not_allowed} = SelectionProcess.V2.transit(enrolled_candidate, event: "register")
     end
+
+    test "__states__/0" do
+      assert SelectionProcess.V1.__states__() == ~w(new registered enrolled)a
+      assert SelectionProcess.V2.__states__() == ~w(new registered interviewed enrolled)a
+    end
+
+    test "__events__/0" do
+      assert SelectionProcess.V1.__events__() == ~w(register enroll)
+      assert SelectionProcess.V2.__events__() == ~w(register interviewed enroll)
+    end
   end
 
   describe "an example of a module handling a different struct with custom state attr" do
@@ -120,6 +146,14 @@ defmodule MachinistTest do
       {:ok, %User{step: 2} = user_step2} = Example4.transit(%User{}, event: "next")
       {:error, :not_allowed} = Example4.transit(user_step2, event: "next")
     end
+
+    test "__states__/0" do
+      assert Example4.__states__() == [1, 2]
+    end
+
+    test "__events__/0" do
+      assert Example4.__events__() == ~w(next)
+    end
   end
 
   describe "an example of a transition from any state to a specific one" do
@@ -134,7 +168,7 @@ defmodule MachinistTest do
 
         from :interview_scheduled do
           to(:approved, event: "approve_interview")
-          to(:repproved, event: "reprove_interview")
+          to(:reproved, event: "reprove_interview")
         end
 
         from(:approved, to: :enrolled, event: "enroll")
@@ -154,6 +188,16 @@ defmodule MachinistTest do
 
       {:ok, %Example5{state: :application_expired}} =
         Example5.transit(%Example5{state: :approved}, event: "application_expired")
+    end
+
+    test "__states__/0" do
+      assert Example5.__states__() ==
+               ~w(new registered interview_scheduled approved reproved enrolled)a
+    end
+
+    test "__events__/0" do
+      assert Example5.__events__() ==
+               ~w(register schedule_interview approve_interview reprove_interview enroll application_expired)
     end
   end
 
@@ -179,6 +223,14 @@ defmodule MachinistTest do
       assert {:ok, %Example6{state: :test2}} = Example6.transit(example, event: "test2")
       assert {:ok, %Example6{state: :test3}} = Example6.transit(example, event: "test3")
       assert {:ok, %Example6{state: :test4}} = Example6.transit(example, event: "test4")
+    end
+
+    test "__states__/0" do
+      assert Example6.__states__() == ~w(test test1 test2 test3 test4)a
+    end
+
+    test "__events__/0" do
+      assert Example6.__events__() == ~w(test1 test2 test3 test4)
     end
   end
 end


### PR DESCRIPTION
Now we can introspect the states, events and transitions with these three functions:

* `__MODULE__.__states__/0`
* `__MODULE__.__events__/0`
* `__MODULE__.__transitions__/0`

Example:

```elixir
defmodule Door do
  defstruct [state: :locked]

  use Machinist

  transitions do
    from :locked,   to: :unlocked, event: "unlock"
    from :unlocked do
      to :locked, event: "lock"
      to :opened, event: "open"
    end
    from :opened,   to: :closed,   event: "close"
    from :closed,   to: :opened,   event: "open"
    from :closed,   to: :locked,   event: "lock"
  end
end
```

```elixir
iex> Door.__states__()
[:locked, :unlocked, :opened, :closed]
```

```elixir
iex> Door.__events__()
["unlock", "lock", "open", "close"]
```

```elixir
iex> Door.__transitions__()
[
  [from: :locked, to: :unlocked, event: "unlock"],
  [from: :unlocked, to: :locked, event: "lock"],
  [from: :unlocked , to: :opened, event: "open"],
  [from: :opened, to: :closed, event: "close"],
  [from: :closed, to: :opened, event: "open"],
  [from: :closed, to: :locked, event: "lock"]
]