### PR TITLE
Add guard to transition

### DIFF
--- a/test/machinist_test.exs
+++ b/test/machinist_test.exs
@@ -386,7 +386,8 @@ defmodule MachinistTest do
     end
 
     test "all transitions" do
-      {:ok, %Example11{state: :awaiting_confirmation} = current_state} = Example11.transit(%Example11{}, event: "activate")
+      {:ok, %Example11{state: :awaiting_confirmation} = current_state} =
+        Example11.transit(%Example11{}, event: "activate")
 
       {:error, :not_allowed} = Example11.transit(current_state, event: "activate")
     end


### PR DESCRIPTION
This PR allows Machinist to define "guards" to validate if an structure should transit between states or not in a more semanthic and visible way.

## Example
```ex
defmodule StateMachineExample do
  transitions do
    from(:created,
      to: :awaiting_confirmation,
      guard: &send_confirmation/1,
      event: "activate"
    )

    from(:awaiting_confirmation,
      to: :confirmed,
      guard: &was_confirmed?/1,
      event: "activate"
    )

    from(:confirmed,
      to: :active,
      event: "activate"
    )
  end

  def send_confirmation(_current_state), do: true

  def was_confirmed?(_current_state), do: false
end
```

Currently, it's required to define guard functions with `arity` 1, the received argument is the current state structure.