### PR TITLE
There is no released 2.2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can install `machinist` by adding it  to your list of dependencies in `mix.e
 ```elixir
 def deps do
   [
-    {:machinist, "~> 2.2.0"}
+    {:machinist, "~> 2.1.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can install `machinist` by adding it  to your list of dependencies in `mix.e
 ```elixir
 def deps do
   [
-    {:machinist, "~> 2.1.0"}
+    {:machinist, "~> 2.1"}
   ]
 end
 ```


### PR DESCRIPTION
We could also change to `"~> 2.1"` to allow automatic feature level updates