### PR TITLE
rename @__struct__ to @___struct___ to use with typespec

### DIFF
--- a/lib/machinist.ex
+++ b/lib/machinist.ex
@@ -12,7 +12,7 @@ defmodule Machinist do
   @doc false
   defmacro __using__(_) do
     quote do
-      @__attr__ :state
+      @___attr___ :state
 
       @behaviour Machinist.Transition
 
@@ -34,7 +34,7 @@ defmodule Machinist do
   """
   defmacro transitions(do: block) do
     quote do
-      @__struct__ __MODULE__
+      @___struct___ __MODULE__
 
       unquote(block)
     end
@@ -84,8 +84,8 @@ defmodule Machinist do
 
   defmacro transitions([attr: attr], do: block) do
     quote do
-      @__attr__ unquote(attr)
-      @__struct__ __MODULE__
+      @___attr___ unquote(attr)
+      @___struct___ __MODULE__
 
       unquote(block)
     end
@@ -93,7 +93,7 @@ defmodule Machinist do
 
   defmacro transitions(struct, do: block) do
     quote do
-      @__struct__ unquote(struct)
+      @___struct___ unquote(struct)
 
       unquote(block)
     end
@@ -109,8 +109,8 @@ defmodule Machinist do
   """
   defmacro transitions(struct, [attr: attr], do: block) do
     quote do
-      @__attr__ unquote(attr)
-      @__struct__ unquote(struct)
+      @___attr___ unquote(attr)
+      @___struct___ unquote(struct)
 
       unquote(block)
     end
@@ -226,10 +226,10 @@ defmodule Machinist do
   defp define_transition(state, to: new_state, event: event) do
     quote do
       @impl true
-      def transit(%@__struct__{@__attr__ => unquote(state)} = resource, event: unquote(event)) do
+      def transit(%@___struct___{@___attr___ => unquote(state)} = resource, event: unquote(event)) do
         case __set_new_state__(resource, unquote(new_state)) do
           {:error, _msg} = term -> term
-          new_state -> {:ok, Map.put(resource, @__attr__, new_state)}
+          new_state -> {:ok, Map.put(resource, @___attr___, new_state)}
         end
       end
     end

--- a/test/machinist_test.exs
+++ b/test/machinist_test.exs
@@ -380,5 +380,4 @@ defmodule MachinistTest do
       assert {:error, :not_allowed} = Example11.transit(step_3, event: "next")
     end
   end
-
 end

--- a/test/machinist_test.exs
+++ b/test/machinist_test.exs
@@ -356,4 +356,29 @@ defmodule MachinistTest do
       end
     end
   end
+
+  describe "an example w/ typespec" do
+    defmodule Example11 do
+      defstruct state: 1
+
+      @type t :: %__MODULE__{
+        state: integer()
+      }
+
+      use Machinist
+
+      transitions do
+        from 1, to: 2, event: "next"
+        from 2, to: 3, event: "next"
+      end
+    end
+
+    test "all transitions" do
+      assert {:ok, %Example11{state: 2} = step_2} = Example11.transit(%Example11{}, event: "next")
+      assert {:ok, %Example11{state: 3} = step_3} = Example11.transit(step_2, event: "next")
+
+      assert {:error, :not_allowed} = Example11.transit(step_3, event: "next")
+    end
+  end
+
 end


### PR DESCRIPTION
i got following compile error when i tried to use machinist module with simple typespec
```
iex(12)> recompile
recompile
Compiling 2 files (.ex)

== Compilation error in file lib/teevr_ctl/state/app.ex ==
** (BadMapError) expected a map, got: TeevrCtl.State.App
    (stdlib 4.2) :maps.remove(:__struct__, TeevrCtl.State.App)
    (elixir 1.14.3) lib/kernel/typespec.ex:561: Kernel.Typespec.typespec/4
    (elixir 1.14.3) lib/kernel/typespec.ex:307: Kernel.Typespec.translate_type/2
    (stdlib 4.2) lists.erl:1462: :lists.mapfoldl_1/3
    (elixir 1.14.3) lib/kernel/typespec.ex:235: Kernel.Typespec.translate_typespecs_for_module/2
** (exit) shutdown: 1
    (mix 1.14.3) lib/mix/tasks/compile.all.ex:78: Mix.Tasks.Compile.All.compile/4
    (mix 1.14.3) lib/mix/tasks/compile.all.ex:59: Mix.Tasks.Compile.All.with_logger_app/2
    (mix 1.14.3) lib/mix/tasks/compile.all.ex:33: Mix.Tasks.Compile.All.run/1
    (mix 1.14.3) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.3) lib/mix/tasks/compile.ex:135: Mix.Tasks.Compile.run/1
    (mix 1.14.3) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (iex 1.14.3) lib/iex/helpers.ex:108: IEx.Helpers.recompile/1
    iex:12: (file)
iex(12)>
```
typespec i added:
```
 @type t :: %__MODULE__{
    state: atom()
  }
```

i think this is name clash or something with typespec after reading some elixir code in `kernel/typespec.ex`.
so i renamed `@__attr__` and `@__struct__` to avoid name clash.
solved my problem.